### PR TITLE
fix: Ensure AUR repo is on master branch after clone

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -428,6 +428,17 @@ jobs:
             git remote add origin ssh://aur@aur.archlinux.org/slskdn-dev.git
           }
 
+      - name: Ensure Master Branch
+        env:
+          AUR_SSH_KEY: ${{ secrets.AUR_SSH_KEY }}
+        run: |
+          if [ -z "$AUR_SSH_KEY" ]; then exit 0; fi
+          
+          cd aur-pkg
+          # Ensure we're on master branch (AUR requires master branch)
+          # If master exists, checkout it; otherwise create it
+          git checkout master 2>/dev/null || git checkout -b master || true
+
       - name: Update PKGBUILD
         env:
           AUR_SSH_KEY: ${{ secrets.AUR_SSH_KEY }}


### PR DESCRIPTION
Fixes AUR build failures by ensuring we checkout master branch after cloning the AUR repo. This handles cases where the AUR repo ends up in detached HEAD state.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Addresses AUR publish failures by enforcing the `master` branch in the CI workflow.
> 
> - In `.github/workflows/dev-release.yml` AUR job, add an "Ensure Master Branch" step to `git checkout master` (or create it) after cloning the AUR repo, aligning with AUR's master-only requirement and preventing detached HEAD states.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c2b1a11129a1b20aa96b96fe3ea31b03f00fbcbc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->