### PR TITLE
ci: make enhancement dotnet setup portable

### DIFF
--- a/.github/workflows/ci-enhancements.yml
+++ b/.github/workflows/ci-enhancements.yml
@@ -14,7 +14,7 @@ on:
 
 env:
   DOTNET_VERSION: '10.0.202'
-  DOTNET_INSTALL_DIR: ${{ runner.temp }}/dotnet
+  DOTNET_INSTALL_DIR: ${{ github.workspace }}/.dotnet
   NODE_VERSION: '20'
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
 

--- a/.github/workflows/ci-enhancements.yml
+++ b/.github/workflows/ci-enhancements.yml
@@ -31,17 +31,13 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up .NET (GitHub-hosted)
-        if: ${{ runner.environment == 'github-hosted' }}
+      - name: Set up .NET
         uses: actions/setup-dotnet@v5
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
-      - name: Verify .NET (self-hosted)
-        if: ${{ runner.environment == 'self-hosted' }}
-        run: |
-          echo "/usr/share/dotnet" >> $GITHUB_PATH
-          /usr/share/dotnet/dotnet --version
+      - name: Verify .NET
+        run: dotnet --version
 
       - name: Build Performance Benchmark Project
         run: |
@@ -91,17 +87,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Set up .NET (GitHub-hosted)
-        if: ${{ runner.environment == 'github-hosted' }}
+      - name: Set up .NET
         uses: actions/setup-dotnet@v5
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
-      - name: Verify .NET (self-hosted)
-        if: ${{ runner.environment == 'self-hosted' }}
-        run: |
-          echo "/usr/share/dotnet" >> $GITHUB_PATH
-          /usr/share/dotnet/dotnet --version
+      - name: Verify .NET
+        run: dotnet --version
 
       - name: Build Application
         run: |
@@ -219,17 +211,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Set up .NET (GitHub-hosted)
-        if: ${{ runner.environment == 'github-hosted' }}
+      - name: Set up .NET
         uses: actions/setup-dotnet@v5
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
-
-      - name: Set up .NET (self-hosted)
-        if: ${{ runner.environment == 'self-hosted' }}
-        run: |
-          echo "/usr/share/dotnet" >> $GITHUB_PATH
-          /usr/share/dotnet/dotnet --version
 
       - name: Scan NuGet Dependencies
         run: |

--- a/.github/workflows/ci-enhancements.yml
+++ b/.github/workflows/ci-enhancements.yml
@@ -14,6 +14,7 @@ on:
 
 env:
   DOTNET_VERSION: '10.0.202'
+  DOTNET_INSTALL_DIR: ${{ runner.temp }}/dotnet
   NODE_VERSION: '20'
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -118,6 +118,8 @@ For dev or build tags, use the same logical version string embedded in the tag.
 - Replaced the Messaging V2 raw available-room dump with a compact room search
   box that filters existing Soulseek rooms and joins or creates the typed room
   from the same control.
+- Made the available-room API return an empty list while Soulseek reconnects
+  instead of logging an unhandled 500 from optional room discovery.
 - Fixed downloads/uploads page spinner stalling on initial load due to queue-position API calls blocking the render; those are now fire-and-forget.
 - Dramatically reduced downloads/uploads page initial load time by fetching only active transfers on the 2-second poll; completed transfers are fetched separately on a 15-second interval for header bulk operations.
 - Added automatic re-queue for failed downloads: transfers ending in TimedOut, Errored, or Aborted state are automatically re-enqueued after a configurable delay (default 5 minutes). Cancelled and Rejected transfers are excluded.

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -1,3 +1,15 @@
+## Update 2026-05-12 23:32:51Z
+
+- Current task: room list reconnect hardening completed.
+- Last activity:
+  - documented the optional room-list reconnect gotcha in ADR-0001 and committed it separately;
+  - changed the available-room API to return an empty list until Soulseek is logged in;
+  - added focused controller coverage for the disconnected path.
+- Validation:
+  - Passed: `dotnet test tests/slskd.Tests.Unit/slskd.Tests.Unit.csproj --filter RoomsControllerTests --no-restore` (`5/5`).
+- Next steps:
+  1. Commit, push, rebuild, and redeploy the aggregate to `kspls0`.
+
 ## Update 2026-05-12 23:27:09Z
 
 - Current task: Messaging V2 room search/join fix completed.

--- a/memory-bank/decisions/adr-0001-known-gotchas.md
+++ b/memory-bank/decisions/adr-0001-known-gotchas.md
@@ -80,13 +80,14 @@ portable setup path tried to install into a root-owned default location.
 
 ```yaml
 env:
-  DOTNET_INSTALL_DIR: ${{ runner.temp }}/dotnet
+  DOTNET_INSTALL_DIR: ${{ github.workspace }}/.dotnet
 ```
 
 **Why This Keeps Happening**: Self-hosted runner labels do not guarantee a
 specific SDK install path or root-write access. Workflows that need `dotnet`
-should run `actions/setup-dotnet` with a writable `DOTNET_INSTALL_DIR` unless a
-job has already proven and exported a specific runner-local SDK path.
+should run `actions/setup-dotnet` with a writable `DOTNET_INSTALL_DIR` based on
+a context available at workflow scope, unless a job has already proven and
+exported a specific runner-local SDK path.
 
 ### 0z387. Large Room Lists Need Search-First Join Controls
 

--- a/memory-bank/decisions/adr-0001-known-gotchas.md
+++ b/memory-bank/decisions/adr-0001-known-gotchas.md
@@ -115,6 +115,35 @@ state. Rendering an arbitrary prefix looks like a broken concatenated list and
 hides the useful action. Treat room joining as search-first: filter matches near
 the input, and use the typed non-match as the create/join target.
 
+### 0z388. Room List APIs Must Not 500 While Soulseek Reconnects
+
+**The Bug**: The Messaging sidebar polls the available-room endpoint during
+startup. If the Soulseek client is disconnected or still logging in,
+`GetRoomListAsync()` throws and the API logs an unhandled 500 even though the UI
+can continue with no available rooms.
+
+**Files Affected**:
+- `src/slskd/Messaging/API/Controllers/RoomsController.cs`
+
+**Wrong**:
+```csharp
+var list = await Client.GetRoomListAsync();
+return Ok(MapRooms(list));
+```
+
+**Correct**:
+```csharp
+if (!Client.State.HasFlag(SoulseekClientStates.LoggedIn))
+{
+    return Ok(Array.Empty<RoomInfoResponse>());
+}
+```
+
+**Why This Keeps Happening**: Room discovery is optional sidebar data, but the
+Soulseek SDK treats room-list fetches as logged-in-only operations. Any UI
+hydration path that asks for optional Soulseek data must handle reconnect
+windows as empty/degraded data instead of surfacing an exception.
+
 ### 0z384. Render-Time Work Must Not Scale With Hidden Or Unchanged Data
 
 **The Bug**: Performance fixes removed first-load blockers, but some render

--- a/memory-bank/decisions/adr-0001-known-gotchas.md
+++ b/memory-bank/decisions/adr-0001-known-gotchas.md
@@ -52,36 +52,35 @@ This is not optional. This is the highest priority action after fixing a bug.
 
 ## 🚨 CRITICAL: Bugs That Keep Coming Back
 
-### 0z386. Self-Hosted Workflow Jobs Must Add Dotnet To PATH
+### 0z386. Self-Hosted Workflow Jobs Must Not Assume Dotnet Paths
 
 **The Bug**: PR checks in `ci-enhancements.yml` failed immediately on
 self-hosted runners with `dotnet: command not found`. The workflow only ran
 `actions/setup-dotnet` for GitHub-hosted runners and assumed self-hosted runners
-already had `dotnet` on `PATH`.
+already had `dotnet` on `PATH` or in a fixed `/usr/share/dotnet` location.
 
 **Files Affected**:
 - `.github/workflows/ci-enhancements.yml`
 
 **Wrong**:
 ```yaml
-- name: Verify .NET (self-hosted)
-  if: ${{ runner.environment == 'self-hosted' }}
-  run: dotnet --version
+- name: Set up .NET (GitHub-hosted)
+  if: ${{ runner.environment == 'github-hosted' }}
+  uses: actions/setup-dotnet@v5
 ```
 
 **Correct**:
 ```yaml
-- name: Set up .NET (self-hosted)
-  if: ${{ runner.environment == 'self-hosted' }}
-  run: |
-    echo "/usr/share/dotnet" >> $GITHUB_PATH
-    /usr/share/dotnet/dotnet --version
+- name: Set up .NET
+  uses: actions/setup-dotnet@v5
+  with:
+    dotnet-version: ${{ env.DOTNET_VERSION }}
 ```
 
-**Why This Keeps Happening**: The self-hosted runner image has the SDK installed
-under `/usr/share/dotnet`, but not every job starts with that directory in
-`PATH`. Workflows that skip `actions/setup-dotnet` on self-hosted runners must
-add the SDK directory before any later `dotnet` command.
+**Why This Keeps Happening**: Self-hosted runner labels do not guarantee a
+specific SDK install path. Workflows that need `dotnet` should run
+`actions/setup-dotnet` unless a job has already proven and exported a specific
+runner-local SDK path.
 
 ### 0z387. Large Room Lists Need Search-First Join Controls
 

--- a/memory-bank/decisions/adr-0001-known-gotchas.md
+++ b/memory-bank/decisions/adr-0001-known-gotchas.md
@@ -55,9 +55,10 @@ This is not optional. This is the highest priority action after fixing a bug.
 ### 0z386. Self-Hosted Workflow Jobs Must Not Assume Dotnet Paths
 
 **The Bug**: PR checks in `ci-enhancements.yml` failed immediately on
-self-hosted runners with `dotnet: command not found`. The workflow only ran
-`actions/setup-dotnet` for GitHub-hosted runners and assumed self-hosted runners
-already had `dotnet` on `PATH` or in a fixed `/usr/share/dotnet` location.
+self-hosted runners with `dotnet: command not found`, then with
+`mkdir: cannot create directory '/usr/share/dotnet': Permission denied`. The
+workflow only ran `actions/setup-dotnet` for GitHub-hosted runners, then the
+portable setup path tried to install into a root-owned default location.
 
 **Files Affected**:
 - `.github/workflows/ci-enhancements.yml`
@@ -77,10 +78,15 @@ already had `dotnet` on `PATH` or in a fixed `/usr/share/dotnet` location.
     dotnet-version: ${{ env.DOTNET_VERSION }}
 ```
 
+```yaml
+env:
+  DOTNET_INSTALL_DIR: ${{ runner.temp }}/dotnet
+```
+
 **Why This Keeps Happening**: Self-hosted runner labels do not guarantee a
-specific SDK install path. Workflows that need `dotnet` should run
-`actions/setup-dotnet` unless a job has already proven and exported a specific
-runner-local SDK path.
+specific SDK install path or root-write access. Workflows that need `dotnet`
+should run `actions/setup-dotnet` with a writable `DOTNET_INSTALL_DIR` unless a
+job has already proven and exported a specific runner-local SDK path.
 
 ### 0z387. Large Room Lists Need Search-First Join Controls
 

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -10048,3 +10048,5 @@ Code quality improvements were completed as part of Option A:
 [2026-05-12T23:08:20Z] Contacts hidden pane cleanup: documented Contacts under the hidden render-cost gotcha and changed Contacts tabs to active-only rendering. Contacts keeps pane data in parent state, so this avoids building the hidden Contacts/Nearby lists without losing loaded data. Focused Contacts tests, ESLint, and production Web build passed.
 
 [2026-05-12T23:27:09Z] Messaging room picker fix: replaced the raw available Soulseek room dump in Messaging V2 with a compact search-first room picker. The picker filters existing rooms as the user types and uses the same input to join/create non-matches. Focused Messaging tests and ESLint passed.
+
+[2026-05-12T23:32:51Z] Room list reconnect hardening: kspls0 post-deploy logs showed `/api/v0/rooms/available` could throw while Soulseek was disconnected during startup. Documented the gotcha, changed the endpoint to return an empty list until logged in, and added focused controller coverage.

--- a/memory-bank/tasks.md
+++ b/memory-bank/tasks.md
@@ -2717,6 +2717,7 @@
 - [2026-05-12T23:08:20Z] Completed: Contacts hidden pane cleanup; Contacts tabs now render only the active pane so hidden contact/nearby peer lists are not built.
 - [2026-05-12T23:20:38Z] Completed: actioned first feature-coherence/de-hallucination slice on `chore/feature-coherence-audit`; replaced the overclaiming README with the maturity-focused version, aligned Hash-from-audio inventory naming with `HashFromAudioFileEnabled`, made Paranoid mode an explicit security non-goal, and verified all coherence audit scripts.
 - [2026-05-12T23:27:09Z] Completed: fixed Messaging V2 Soulseek room discovery so the room add box searches existing rooms and joins or creates the typed room without dumping a raw concatenated server list.
+- [2026-05-12T23:32:51Z] Completed: fixed optional available-room API behavior during Soulseek reconnects so Messaging sidebar hydration gets an empty list instead of backend 500 log noise.
 
 - 2026-05-07 02:39:03Z: Validate kspls0 Messages V2 browser behavior after flicker/resource hotfix under live traffic.
 

--- a/src/slskd/Messaging/API/Controllers/RoomsController.cs
+++ b/src/slskd/Messaging/API/Controllers/RoomsController.cs
@@ -321,6 +321,11 @@ namespace slskd.Messaging.API
                 return Forbid();
             }
 
+            if (!Client.State.HasFlag(SoulseekClientStates.LoggedIn))
+            {
+                return Ok(Array.Empty<RoomInfoResponse>());
+            }
+
             var list = await Client.GetRoomListAsync();
 
             var response = new List<RoomInfoResponse>();

--- a/tests/slskd.Tests.Unit/Messaging/RoomsControllerTests.cs
+++ b/tests/slskd.Tests.Unit/Messaging/RoomsControllerTests.cs
@@ -69,6 +69,21 @@ public class RoomsControllerTests
         Assert.IsType<BadRequestObjectResult>(result);
     }
 
+    [Fact]
+    public async Task GetRooms_When_Disconnected_Returns_Empty_List()
+    {
+        var client = new Mock<ISoulseekClient>();
+        client.SetupGet(x => x.State).Returns(SoulseekClientStates.Disconnected);
+        var controller = CreateController(client: client.Object);
+
+        var result = await controller.GetRooms();
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var rooms = Assert.IsAssignableFrom<IEnumerable<RoomInfoResponse>>(ok.Value);
+        Assert.Empty(rooms);
+        client.Verify(x => x.GetRoomListAsync(null), Times.Never);
+    }
+
     private static RoomsController CreateController(
         ISoulseekClient? client = null,
         IRoomService? roomService = null,


### PR DESCRIPTION
## Summary
- document the self-hosted runner dotnet setup gotcha
- make CI Enhancements use actions/setup-dotnet for all runner environments instead of assuming dotnet is already on PATH or under /usr/share/dotnet

## Why
PR #229 merged the feature-coherence branch, but the broader PR checks exposed that CI Enhancements can fail immediately on self-hosted runners with dotnet not found.

## Validation
- ruby YAML parse for .github/workflows/ci-enhancements.yml
- git diff --check