### PR TITLE
Fix live listener reconfiguration state and obfuscation

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,6 +22,9 @@ For dev or build tags, use the same logical version string embedded in the tag.
 
 ## [Unreleased]
 
+- Listener IP and port changes no longer report a reconnect requirement after
+  Soulseek.NET has already rebound the live listeners and advertised the new
+  endpoint to the Soulseek server.
 - The web footer and README now offer direct PayPal and Ko-fi links for
   supporting slskdN development.
 - GitLab CI configuration now keeps the Arch package-smoke sudoers command as

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -25,6 +25,9 @@ For dev or build tags, use the same logical version string embedded in the tag.
 - Listener IP and port changes no longer report a reconnect requirement after
   Soulseek.NET has already rebound the live listeners and advertised the new
   endpoint to the Soulseek server.
+- Live Soulseek listener changes now apply updated type-1 obfuscation options
+  before rebinding, keeping the obfuscated socket and advertised metadata on
+  the configured port instead of the previous one.
 - The web footer and README now offer direct PayPal and Ko-fi links for
   supporting slskdN development.
 - GitLab CI configuration now keeps the Arch package-smoke sudoers command as

--- a/src/slskd/Core/Options.cs
+++ b/src/slskd/Core/Options.cs
@@ -2546,7 +2546,6 @@ namespace slskd
             [EnvironmentVariable("SLSK_LISTEN_IP_ADDRESS")]
             [Description("local IP address on which to listen for incoming connections")]
             [IPAddress]
-            [RequiresReconnect]
             public string ListenIpAddress { get; init; } = "0.0.0.0";
 
             /// <summary>
@@ -2556,7 +2555,6 @@ namespace slskd
             [EnvironmentVariable("SLSK_LISTEN_PORT")]
             [Description("port on which to listen for incoming connections")]
             [Range(1024, 65535)]
-            [RequiresReconnect]
             public int ListenPort { get; init; } = 50300;
 
             /// <summary>

--- a/tests/slskd.Tests.Unit/Core/ApplicationLifecycleTests.cs
+++ b/tests/slskd.Tests.Unit/Core/ApplicationLifecycleTests.cs
@@ -172,8 +172,10 @@ public class ApplicationLifecycleTests
         soulseekClient.VerifyRemove(x => x.ExcludedSearchPhrasesReceived -= It.IsAny<EventHandler<IReadOnlyCollection<string>>>(), Times.Once);
     }
 
-    [Fact]
-    public async Task OptionsChanged_WhenListenPortChangesWhileConnected_SetsPendingReconnect()
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task OptionsChanged_WhenListenerReconfigurationSucceeds_DoesNotSetPendingReconnect(bool changeIpAddress)
     {
         var optionsMonitor = new TestOptionsMonitor<Options>(new Options());
         var applicationState = new ManagedState<State>();
@@ -199,13 +201,14 @@ public class ApplicationLifecycleTests
         {
             Soulseek = new Options.SoulseekOptions
             {
-                ListenPort = 50301,
+                ListenIpAddress = changeIpAddress ? "0.0.0.1" : "0.0.0.0",
+                ListenPort = changeIpAddress ? 50300 : 50301,
             },
         });
 
         await reconfigured.Task.WaitAsync(TimeSpan.FromSeconds(5));
 
-        Assert.True(applicationState.CurrentValue.PendingReconnect);
+        Assert.False(applicationState.CurrentValue.PendingReconnect);
         application.Dispose();
     }
 

--- a/vendor/slskNet.Runtime/src/SoulseekClient.cs
+++ b/vendor/slskNet.Runtime/src/SoulseekClient.cs
@@ -4612,8 +4612,17 @@ namespace Soulseek
                 var listenAddressChanged = patch.ListenIPAddress != null && !patch.ListenIPAddress.Equals(Options.ListenIPAddress);
                 var listenPortChanged = patch.ListenPort.HasValue && patch.ListenPort.Value != Options.ListenPort;
                 var incomingConnectionOptionsChanged = patch.IncomingConnectionOptions != null && patch.IncomingConnectionOptions != Options.IncomingConnectionOptions;
+                var peerObfuscationOptionsChanged = patch.PeerObfuscationOptions != null &&
+                    (patch.PeerObfuscationOptions.Enabled != Options.PeerObfuscationOptions.Enabled ||
+                     patch.PeerObfuscationOptions.ListenPort != Options.PeerObfuscationOptions.ListenPort ||
+                     patch.PeerObfuscationOptions.Type != Options.PeerObfuscationOptions.Type ||
+                     patch.PeerObfuscationOptions.AdvertiseRegularPort != Options.PeerObfuscationOptions.AdvertiseRegularPort ||
+                     patch.PeerObfuscationOptions.PreferOutbound != Options.PeerObfuscationOptions.PreferOutbound);
+                var peerObfuscationListenerChanged = peerObfuscationOptionsChanged &&
+                    (patch.PeerObfuscationOptions.Enabled != Options.PeerObfuscationOptions.Enabled ||
+                     patch.PeerObfuscationOptions.ListenPort != Options.PeerObfuscationOptions.ListenPort);
 
-                if (enableListenerChanged || listenAddressChanged || listenPortChanged || incomingConnectionOptionsChanged)
+                if (enableListenerChanged || listenAddressChanged || listenPortChanged || incomingConnectionOptionsChanged || peerObfuscationListenerChanged)
                 {
                     var wasListening = Listener?.Listening ?? false;
 
@@ -4626,7 +4635,8 @@ namespace Soulseek
                         enableListener: patch.EnableListener,
                         listenIPAddress: patch.ListenIPAddress,
                         listenPort: patch.ListenPort,
-                        incomingConnectionOptions: patch.IncomingConnectionOptions);
+                        incomingConnectionOptions: patch.IncomingConnectionOptions,
+                        peerObfuscationOptions: patch.PeerObfuscationOptions);
 
                     if (wasListening && Options.EnableListener)
                     {
@@ -4664,6 +4674,7 @@ namespace Soulseek
                     peerConnectionOptions: patch.PeerConnectionOptions,
                     transferConnectionOptions: patch.TransferConnectionOptions,
                     incomingConnectionOptions: patch.IncomingConnectionOptions,
+                    peerObfuscationOptions: patch.PeerObfuscationOptions,
                     distributedConnectionOptions: patch.DistributedConnectionOptions,
                     userEndPointCache: patch.UserEndPointCache,
                     searchResponseResolver: patch.SearchResponseResolver,

--- a/vendor/slskNet.Runtime/tests/Soulseek.Tests.Unit/Client/ReconfigureOptionsAsyncTests.cs
+++ b/vendor/slskNet.Runtime/tests/Soulseek.Tests.Unit/Client/ReconfigureOptionsAsyncTests.cs
@@ -319,6 +319,53 @@ namespace Soulseek.Tests.Unit.Client
         }
 
         [Trait("Category", "ReconfigureOptions")]
+        [Fact(DisplayName = "Reconfigures obfuscated listener and metadata if listen ports changed")]
+        public async Task Reconfigures_Obfuscated_Listener_And_Metadata_If_Listen_Ports_Changed()
+        {
+            var regularPort = GetAvailablePort();
+            var oldObfuscatedPort = GetAvailablePort();
+            while (oldObfuscatedPort == regularPort)
+            {
+                oldObfuscatedPort = GetAvailablePort();
+            }
+
+            var newRegularPort = GetAvailablePort();
+            while (newRegularPort == regularPort || newRegularPort == oldObfuscatedPort)
+            {
+                newRegularPort = GetAvailablePort();
+            }
+
+            var newObfuscatedPort = GetAvailablePort();
+            while (newObfuscatedPort == regularPort || newObfuscatedPort == oldObfuscatedPort || newObfuscatedPort == newRegularPort)
+            {
+                newObfuscatedPort = GetAvailablePort();
+            }
+
+            var oldObfuscation = new PeerObfuscationOptions(enabled: true, listenPort: oldObfuscatedPort);
+            var newObfuscation = new PeerObfuscationOptions(enabled: true, listenPort: newObfuscatedPort, preferOutbound: true);
+            var (client, mocks) = GetFixture(new SoulseekClientOptions(
+                listenPort: regularPort,
+                peerObfuscationOptions: oldObfuscation));
+
+            mocks.Listener.Setup(m => m.Listening).Returns(true);
+            var patch = new SoulseekClientOptionsPatch(
+                listenPort: newRegularPort,
+                peerObfuscationOptions: newObfuscation);
+
+            using (client)
+            {
+                client.SetProperty("State", SoulseekClientStates.Connected | SoulseekClientStates.LoggedIn);
+
+                await client.ReconfigureOptionsAsync(patch);
+
+                Assert.Equal(newRegularPort, client.Listener.Port);
+                Assert.NotNull(client.ObfuscatedListener);
+                Assert.Equal(newObfuscatedPort, client.ObfuscatedListener.Port);
+                Assert.Same(newObfuscation, client.Options.PeerObfuscationOptions);
+            }
+        }
+
+        [Trait("Category", "ReconfigureOptions")]
         [Fact(DisplayName = "Reconfigures listener if ListenIPAddress changed")]
         public async Task Reconfigures_Listener_If_ListenIPAddress_Changed()
         {


### PR DESCRIPTION
## What changed

- remove `RequiresReconnect` from `soulseek.listen_ip_address` and `soulseek.listen_port`
- apply live `PeerObfuscationOptions` patches before listener rebinding
- update lifecycle and vendored Soulseek.NET regression coverage
- document both corrected runtime behaviors

## Root causes

`Application.OptionsMonitor_OnChange` ORed the option attributes into `PendingReconnect` even when `SoulseekClient.ReconfigureOptionsAsync(...)` returned `false`. Soulseek.NET already rebinds the regular listener and advertises it without reconnecting.

The vendored Soulseek.NET runtime also omitted `PeerObfuscationOptions` from both `Options.With(...)` calls during reconfiguration. A regular port change therefore rebound and advertised the new regular endpoint while retaining the old type-1 listener port and metadata until restart.

Frozen-runtime differentials reproduced both contradictions with a login-capable local Soulseek server and direct socket probes.

## Validation

- `dotnet test tests/slskd.Tests.Unit/slskd.Tests.Unit.csproj --filter FullyQualifiedName~ApplicationLifecycleTests -v:minimal` — 8 passed
- `dotnet test vendor/slskNet.Runtime/tests/Soulseek.Tests.Unit/Soulseek.Tests.Unit.csproj --filter FullyQualifiedName~ReconfigureOptionsAsyncTests -v:minimal` — 29 passed
- fixed-runtime differential: regular and derived type-1 sockets plus SetListenPort metadata match the candidate implementation; only the intentionally removed stale pendingReconnect state differs
- `git diff --check`