### PR TITLE
Fix adversarial options injection

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,6 +22,9 @@ For dev or build tags, use the same logical version string embedded in the tag.
 
 ## [Unreleased]
 
+- The security controller now consumes registered adversarial settings through
+  `IOptions`, so its settings endpoint no longer reports that configured
+  adversarial features are unavailable.
 - The web footer and README now offer direct PayPal and Ko-fi links for
   supporting slskdN development.
 - GitLab CI configuration now keeps the Arch package-smoke sudoers command as

--- a/src/slskd/Common/Security/API/SecurityController.cs
+++ b/src/slskd/Common/Security/API/SecurityController.cs
@@ -48,7 +48,7 @@ public class SecurityController : ControllerBase
     public SecurityController(
         SecurityServices? security = null,
         ISecurityEventSink? eventSink = null,
-        AdversarialOptions? adversarialOptions = null,
+        IOptions<AdversarialOptions>? adversarialOptions = null,
         AnonymityTransportSelector? transportSelector = null,
         Mesh.IMeshCircuitBuilder? circuitBuilder = null,
         Mesh.IMeshPeerManager? peerManager = null,
@@ -57,7 +57,7 @@ public class SecurityController : ControllerBase
     {
         _security = security;
         _eventSink = eventSink ?? security?.EventSink;
-        _adversarialOptions = adversarialOptions;
+        _adversarialOptions = adversarialOptions?.Value;
         _transportSelector = transportSelector;
         _circuitBuilder = circuitBuilder;
         _peerManager = peerManager;

--- a/tests/slskd.Tests.Unit/Common/Security/SecurityControllerTests.cs
+++ b/tests/slskd.Tests.Unit/Common/Security/SecurityControllerTests.cs
@@ -110,7 +110,9 @@ public class SecurityControllerTests
         return new SecurityController(
             security,
             security?.EventSink,
-            adversarialOptions,
+            adversarialOptions == null
+                ? null
+                : Microsoft.Extensions.Options.Options.Create(adversarialOptions),
             null,
             circuitBuilder,
             null,


### PR DESCRIPTION
## What changed

- inject `IOptions<AdversarialOptions>` into `SecurityController`
- retain the resolved value for the existing settings and statistics endpoints
- update the focused controller test and changelog

## Root cause

The experimental service graph registers `AdversarialOptions` through the options framework, but `SecurityController` requested the value object directly. Dependency injection therefore supplied the constructor's optional `null` default, and `GET /api/v0/security/adversarial` returned 404 even when adversarial settings were configured.

## Impact

Configured adversarial settings are now available to the security controller through the same registration used by the rest of the service graph.

## Validation

`dotnet test tests/slskd.Tests.Unit/slskd.Tests.Unit.csproj -c Release --filter FullyQualifiedName~SecurityControllerTests --no-restore`

Result: 6 passed.