### PR TITLE
Validate obfuscation regular port advertisement

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,6 +22,9 @@ For dev or build tags, use the same logical version string embedded in the tag.
 
 ## [Unreleased]
 
+- Soulseek obfuscation configuration now rejects disabling regular-port
+  advertisement before runtime construction instead of terminating during
+  application startup.
 - The web footer and README now offer direct PayPal and Ko-fi links for
   supporting slskdN development.
 - GitLab CI configuration now keeps the Arch package-smoke sudoers command as

--- a/src/slskd/Core/Options.cs
+++ b/src/slskd/Core/Options.cs
@@ -2707,6 +2707,13 @@ namespace slskd
                             [nameof(ListenPort)]));
                     }
 
+                    if (Enabled && !AdvertiseRegularPort)
+                    {
+                        results.Add(new ValidationResult(
+                            "Soulseek obfuscation requires the regular peer port to remain advertised for legacy compatibility.",
+                            [nameof(AdvertiseRegularPort)]));
+                    }
+
                     if (Enabled && mode == SoulseekObfuscationMode.Only)
                     {
                         results.Add(new ValidationResult(

--- a/tests/slskd.Tests.Unit/SoulseekOptionsValidationTests.cs
+++ b/tests/slskd.Tests.Unit/SoulseekOptionsValidationTests.cs
@@ -127,6 +127,31 @@ public class SoulseekOptionsValidationTests
     }
 
     [Fact]
+    public void Options_RejectsEnabledObfuscationWithoutRegularPortAdvertisement()
+    {
+        var options = new Options
+        {
+            Soulseek = new Options.SoulseekOptions
+            {
+                Obfuscation = new Options.SoulseekOptions.ObfuscationOptions
+                {
+                    Enabled = true,
+                    Mode = SoulseekObfuscationMode.Compatibility.ToString(),
+                    AdvertiseRegularPort = false,
+                },
+            },
+        };
+
+        var results = options.Validate(new ValidationContext(options)).ToList();
+
+        Assert.Contains(
+            results,
+            result => result.ErrorMessage!.Contains(
+                "regular peer port to remain advertised",
+                System.StringComparison.Ordinal));
+    }
+
+    [Fact]
     public void SoulseekObfuscationPlan_ReportsConfiguredActiveRuntime()
     {
         var plan = SoulseekObfuscationSupport.BuildPlan(new Options.SoulseekOptions


### PR DESCRIPTION
## What changed

- Reject `soulseek.obfuscation.advertise_regular_port: false` when obfuscation is enabled.
- Add a focused regression test for compatibility mode.
- Document the startup fix in the Unreleased changelog.

## Root cause

The public options validator accepted the unsupported combination, but `PeerObfuscationOptions` rejected it later during dependency construction. The daemon therefore terminated with an `ArgumentException` instead of reporting invalid configuration.

## User impact

Invalid obfuscation configuration now fails early with a clear validation error and a non-zero exit status, instead of reaching runtime construction and terminating unexpectedly.

## Validation

- `dotnet test tests/slskd.Tests.Unit/slskd.Tests.Unit.csproj -c Release --filter FullyQualifiedName~SoulseekOptionsValidationTests` — 11 passed.
- Startup reproduction with `SLSKD_SLSK_OBFUSCATION=true` and `SLSKD_SLSK_OBFUSCATION_ADVERTISE_REGULAR_PORT=false` now reports `Invalid configuration` and exits 1.