### PR TITLE
retain valid options after rejected reload

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,6 +22,9 @@ For dev or build tags, use the same logical version string embedded in the tag.
 
 ## [Unreleased]
 
+- Invalid watched configuration reloads now retain the last valid options for
+  background services instead of allowing an options validation exception to
+  stop the entire application.
 - The web footer and README now offer direct PayPal and Ko-fi links for
   supporting slskdN development.
 - GitLab CI configuration now keeps the Arch package-smoke sudoers command as

--- a/src/slskd/Bootstrap/ApplicationHostServiceCollectionExtensions.cs
+++ b/src/slskd/Bootstrap/ApplicationHostServiceCollectionExtensions.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Serilog;
 using slskd.Authentication;
+using slskd.Common.Configuration;
 using slskd.Core.Features;
 using slskd.Player;
 using slskd.Core.API;
@@ -54,6 +55,7 @@ public static class ApplicationHostServiceCollectionExtensions
 
                 return true;
             });
+        services.AddSingleton<IOptionsMonitor<slskd.Options>, RetainingOptionsMonitor<slskd.Options>>();
 
         services.AddSingleton<IFeatureGate, FeatureGate>();
 

--- a/src/slskd/Common/Configuration/RetainingOptionsMonitor.cs
+++ b/src/slskd/Common/Configuration/RetainingOptionsMonitor.cs
@@ -1,0 +1,181 @@
+// <copyright file="RetainingOptionsMonitor.cs" company="slskdN Team">
+//     Copyright (c) slskdN Team. All rights reserved.
+// </copyright>
+
+namespace slskd.Common.Configuration;
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Primitives;
+using Serilog;
+
+/// <summary>
+///     An options monitor that retains the last valid value when a configuration reload is invalid.
+/// </summary>
+/// <typeparam name="TOptions">The options type.</typeparam>
+public sealed class RetainingOptionsMonitor<TOptions> : IOptionsMonitor<TOptions>, IDisposable
+    where TOptions : class
+{
+    private readonly IOptionsFactory<TOptions> factory;
+    private readonly object sync = new();
+    private readonly Dictionary<string, TOptions> values = new(StringComparer.Ordinal);
+    private readonly List<IDisposable> changeTokenRegistrations = new();
+    private Action<TOptions, string?>? listeners;
+    private bool disposed;
+
+    /// <summary>
+    ///     Initializes a new instance of the <see cref="RetainingOptionsMonitor{TOptions}"/> class.
+    /// </summary>
+    /// <param name="factory">The options factory.</param>
+    /// <param name="sources">The configuration change token sources.</param>
+    public RetainingOptionsMonitor(
+        IOptionsFactory<TOptions> factory,
+        IEnumerable<IOptionsChangeTokenSource<TOptions>> sources)
+    {
+        this.factory = factory;
+
+        foreach (var source in sources)
+        {
+            changeTokenRegistrations.Add(ChangeToken.OnChange(
+                source.GetChangeToken,
+                InvokeChanged,
+                source.Name));
+        }
+    }
+
+    /// <inheritdoc />
+    public TOptions CurrentValue => Get(Options.DefaultName);
+
+    /// <inheritdoc />
+    public TOptions Get(string? name)
+    {
+        name ??= Options.DefaultName;
+
+        lock (sync)
+        {
+            ObjectDisposedException.ThrowIf(disposed, this);
+
+            if (values.TryGetValue(name, out var value))
+            {
+                return value;
+            }
+        }
+
+        var created = factory.Create(name);
+
+        lock (sync)
+        {
+            ObjectDisposedException.ThrowIf(disposed, this);
+
+            if (values.TryGetValue(name, out var value))
+            {
+                return value;
+            }
+
+            values.Add(name, created);
+            return created;
+        }
+    }
+
+    /// <inheritdoc />
+    public IDisposable OnChange(Action<TOptions, string?> listener)
+    {
+        ArgumentNullException.ThrowIfNull(listener);
+
+        lock (sync)
+        {
+            ObjectDisposedException.ThrowIf(disposed, this);
+            listeners += listener;
+        }
+
+        return new Subscription(this, listener);
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        List<IDisposable> registrations;
+
+        lock (sync)
+        {
+            if (disposed)
+            {
+                return;
+            }
+
+            disposed = true;
+            listeners = null;
+            registrations = new List<IDisposable>(changeTokenRegistrations);
+            changeTokenRegistrations.Clear();
+            values.Clear();
+        }
+
+        foreach (var registration in registrations)
+        {
+            registration.Dispose();
+        }
+    }
+
+    private void InvokeChanged(string? name)
+    {
+        name ??= Options.DefaultName;
+
+        TOptions created;
+        try
+        {
+            created = factory.Create(name);
+        }
+        catch (Exception ex)
+        {
+            Log.Warning(ex, "Options reload rejected; retaining the last valid configuration");
+            return;
+        }
+
+        Action<TOptions, string?>? callbacks;
+        lock (sync)
+        {
+            if (disposed)
+            {
+                return;
+            }
+
+            values[name] = created;
+            callbacks = listeners;
+        }
+
+        callbacks?.Invoke(created, name);
+    }
+
+    private void Unsubscribe(Action<TOptions, string?> listener)
+    {
+        lock (sync)
+        {
+            listeners -= listener;
+        }
+    }
+
+    private sealed class Subscription : IDisposable
+    {
+        private RetainingOptionsMonitor<TOptions>? monitor;
+        private Action<TOptions, string?>? listener;
+
+        public Subscription(RetainingOptionsMonitor<TOptions> monitor, Action<TOptions, string?> listener)
+        {
+            this.monitor = monitor;
+            this.listener = listener;
+        }
+
+        public void Dispose()
+        {
+            var currentMonitor = Interlocked.Exchange(ref monitor, null);
+            var currentListener = Interlocked.Exchange(ref listener, null);
+
+            if (currentMonitor is not null && currentListener is not null)
+            {
+                currentMonitor.Unsubscribe(currentListener);
+            }
+        }
+    }
+}

--- a/tests/slskd.Tests/RetainingOptionsMonitorTests.cs
+++ b/tests/slskd.Tests/RetainingOptionsMonitorTests.cs
@@ -1,0 +1,86 @@
+// <copyright file="RetainingOptionsMonitorTests.cs" company="slskdN Team">
+//     Copyright (c) slskdN Team. All rights reserved.
+// </copyright>
+
+namespace slskd.Tests;
+
+using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Primitives;
+using slskd.Common.Configuration;
+using Xunit;
+
+public class RetainingOptionsMonitorTests
+{
+    [Fact]
+    public void Invalid_reload_retains_last_valid_value_and_later_valid_reload_applies()
+    {
+        var source = new TestChangeTokenSource<TestOptions>();
+        var factory = new TestOptionsFactory(new TestOptions { Value = 1 });
+        using var monitor = new RetainingOptionsMonitor<TestOptions>(factory, new[] { source });
+        var changes = new List<int>();
+        using var registration = monitor.OnChange((options, _) => changes.Add(options.Value));
+
+        Assert.Equal(1, monitor.CurrentValue.Value);
+
+        factory.Exception = new OptionsValidationException(
+            Options.DefaultName,
+            typeof(TestOptions),
+            new[] { "invalid" });
+        source.SignalChange();
+
+        Assert.Equal(1, monitor.CurrentValue.Value);
+        Assert.Empty(changes);
+
+        factory.Exception = null;
+        factory.Value = new TestOptions { Value = 2 };
+        source.SignalChange();
+
+        Assert.Equal(2, monitor.CurrentValue.Value);
+        Assert.Equal(new[] { 2 }, changes);
+    }
+
+    private sealed class TestOptions
+    {
+        public int Value { get; init; }
+    }
+
+    private sealed class TestOptionsFactory : IOptionsFactory<TestOptions>
+    {
+        public TestOptionsFactory(TestOptions value)
+        {
+            Value = value;
+        }
+
+        public TestOptions Value { get; set; }
+        public Exception? Exception { get; set; }
+
+        public TestOptions Create(string name)
+        {
+            if (Exception is not null)
+            {
+                throw Exception;
+            }
+
+            return Value;
+        }
+    }
+
+    private sealed class TestChangeTokenSource<TOptions> : IOptionsChangeTokenSource<TOptions>
+    {
+        private CancellationTokenSource cancellationTokenSource = new();
+
+        public string Name => Options.DefaultName;
+
+        public IChangeToken GetChangeToken() => new CancellationChangeToken(cancellationTokenSource.Token);
+
+        public void SignalChange()
+        {
+            var previous = cancellationTokenSource;
+            cancellationTokenSource = new CancellationTokenSource();
+            previous.Cancel();
+            previous.Dispose();
+        }
+    }
+}


### PR DESCRIPTION
## What changed

- register a retaining options monitor for the root slskd options
- keep the last validated options object when a watched reload is invalid
- continue applying later valid reloads and notifying change subscribers
- add a focused regression and changelog entry

## Root cause

The default `OptionsMonitor` evicts its cached value before constructing and validating the replacement. When a watched file contains an invalid value, construction throws `OptionsValidationException` and leaves the cache empty. Background services then resolve the same invalid options object; an unhandled exception from `WishlistService` reaches the default `StopHost` behavior and shuts down the entire application.

## Impact

Invalid watched configuration still receives the existing validation failure, but singleton and background consumers continue using the last valid configuration. A later valid file change is applied normally without restarting the process.

## Validation

- `dotnet test tests/slskd.Tests/slskd.Tests.csproj --no-restore`: 70 passed
- focused retaining-monitor regression: passed
- `dotnet format slskd.sln whitespace --verify-no-changes --include ...`: passed
- live listener lifecycle: invalid `soulseek.listen_port: 1023` rejected, host retained its valid runtime options, subsequent valid reload applied
- external differential listener suite against slskdN current main plus both frozen slskd/slskdN compatibility targets: passed
