### PR TITLE
fix auto-retry tolerance range validation

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,6 +22,8 @@ For dev or build tags, use the same logical version string embedded in the tag.
 
 ## [Unreleased]
 
+- Download auto-retry now rejects fractional alternate-source size tolerances
+  outside the configured 0–100 percent range instead of rounding them into it.
 - The web footer and README now offer direct PayPal and Ko-fi links for
   supporting slskdN development.
 - GitLab CI configuration now keeps the Arch package-smoke sudoers command as

--- a/src/slskd/Core/Options.cs
+++ b/src/slskd/Core/Options.cs
@@ -1433,7 +1433,7 @@ namespace slskd
                     /// <summary>
                     ///     Gets the maximum size difference percentage accepted for alternate-source retry candidates.
                     /// </summary>
-                    [Range(0, 100)]
+                    [Range(0.0, 100.0)]
                     public double AlternateSourceSizeTolerancePercent { get; init; } = 5.0;
                 }
             }

--- a/tests/slskd.Tests.Unit/Core/API/OptionsControllerTests.cs
+++ b/tests/slskd.Tests.Unit/Core/API/OptionsControllerTests.cs
@@ -167,6 +167,20 @@ public class OptionsControllerTests
         Assert.Equal("Invalid YAML configuration", ok.Value);
     }
 
+    [Theory]
+    [InlineData("-0.1")]
+    [InlineData("100.1")]
+    public void ValidateYamlFile_WithOutOfRangeAutoRetryTolerance_ReturnsInvalidConfiguration(string tolerance)
+    {
+        var controller = CreateController();
+        var yaml = $"transfers:\n  download:\n    auto_retry:\n      alternate_source_size_tolerance_percent: {tolerance}";
+
+        var result = controller.ValidateYamlFile(yaml);
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        Assert.Equal("Invalid YAML configuration", ok.Value);
+    }
+
     [Fact]
     public void ApplyOverlay_WithInvalidOverlay_DoesNotLeakValidationMessage()
     {


### PR DESCRIPTION
## What changed

- use a `double`-typed `RangeAttribute` for the download auto-retry alternate-source size tolerance
- add controller validation coverage for fractional values immediately outside the documented 0–100 percent range
- document the fix in the Unreleased changelog

## Why

The property is a `double`, but its range annotation used integer operands. `RangeAttribute` converted fractional values to integers during validation, so values such as `-0.1` and `100.1` rounded into the accepted range.

## Impact

YAML validation and startup validation now reject every fractional tolerance below 0 or above 100 instead of accepting values close to the boundaries.

## Validation

`dotnet test tests/slskd.Tests.Unit/slskd.Tests.Unit.csproj -c Release --filter 'FullyQualifiedName~OptionsControllerTests' --no-restore`
