### PR TITLE
Validate documented transfers.groups YAML

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,6 +22,8 @@ For dev or build tags, use the same logical version string embedded in the tag.
 
 ## [Unreleased]
 
+- YAML validation now accepts the documented `transfers.groups` placement and
+  applies the same top-level `groups` precedence as runtime configuration.
 - The web footer and README now offer direct PayPal and Ko-fi links for
   supporting slskdN development.
 - GitLab CI configuration now keeps the Arch package-smoke sudoers command as

--- a/src/slskd/Core/API/Controllers/OptionsController.cs
+++ b/src/slskd/Core/API/Controllers/OptionsController.cs
@@ -24,6 +24,7 @@ namespace slskd.Core.API
 {
     using System;
     using System.IO;
+    using System.Linq;
     using System.Reflection;
     using System.Text.RegularExpressions;
     using Asp.Versioning;
@@ -33,6 +34,7 @@ namespace slskd.Core.API
     using Serilog;
     using slskd.Core.Security;
     using slskd.Validation;
+    using YamlDotNet.RepresentationModel;
     using IOFile = System.IO.File;
 
     /// <summary>
@@ -269,7 +271,7 @@ namespace slskd.Core.API
 
             try
             {
-                var options = yaml.FromYaml<Options>();
+                var options = NormalizeCompatibilityYaml(yaml).FromYaml<Options>();
 
                 if (options is null)
                 {
@@ -293,6 +295,87 @@ namespace slskd.Core.API
 
             return true;
         }
+
+        private static string NormalizeCompatibilityYaml(string yaml)
+        {
+            var stream = new YamlStream();
+
+            using (var reader = new StringReader(yaml))
+            {
+                stream.Load(reader);
+            }
+
+            if (stream.Documents.Count == 0 || stream.Documents[0].RootNode is not YamlMappingNode root ||
+                !TryGetMappingChild(root, "transfers", out _, out var transfersNode) ||
+                transfersNode is not YamlMappingNode transfers ||
+                !TryGetMappingChild(transfers, "groups", out var transfersGroupsKey, out var transfersGroupsNode))
+            {
+                return yaml;
+            }
+
+            transfers.Children.Remove(transfersGroupsKey);
+
+            if (TryGetMappingChild(root, "groups", out _, out var rootGroupsNode))
+            {
+                if (rootGroupsNode is YamlMappingNode rootGroups && transfersGroupsNode is YamlMappingNode transfersGroups)
+                {
+                    MergeMissingYamlChildren(rootGroups, transfersGroups);
+                }
+            }
+            else
+            {
+                root.Children.Add(new YamlScalarNode("groups"), transfersGroupsNode);
+            }
+
+            using var writer = new StringWriter();
+            stream.Save(writer, assignAnchors: false);
+            return writer.ToString();
+        }
+
+        private static void MergeMissingYamlChildren(YamlMappingNode target, YamlMappingNode source)
+        {
+            foreach (var child in source.Children.ToArray())
+            {
+                var name = (child.Key as YamlScalarNode)?.Value;
+                if (name is not null && TryGetMappingChild(target, name, out _, out var existing))
+                {
+                    if (existing is YamlMappingNode existingMap && child.Value is YamlMappingNode childMap)
+                    {
+                        MergeMissingYamlChildren(existingMap, childMap);
+                    }
+
+                    continue;
+                }
+
+                target.Children.Add(child.Key, child.Value);
+            }
+        }
+
+        private static bool TryGetMappingChild(
+            YamlMappingNode mapping,
+            string name,
+            out YamlNode key,
+            out YamlNode value)
+        {
+            var normalizedName = NormalizeYamlKey(name);
+
+            foreach (var child in mapping.Children)
+            {
+                if (child.Key is YamlScalarNode scalar && NormalizeYamlKey(scalar.Value) == normalizedName)
+                {
+                    key = child.Key;
+                    value = child.Value;
+                    return true;
+                }
+            }
+
+            key = null!;
+            value = null!;
+            return false;
+        }
+
+        private static string NormalizeYamlKey(string? value)
+            => (value ?? string.Empty).Replace("_", string.Empty).Replace("-", string.Empty).ToLowerInvariant();
 
         private static string RedactConfigurationDebugView(string debugView)
         {

--- a/tests/slskd.Tests.Unit/Core/API/OptionsControllerTests.cs
+++ b/tests/slskd.Tests.Unit/Core/API/OptionsControllerTests.cs
@@ -168,6 +168,74 @@ public class OptionsControllerTests
     }
 
     [Fact]
+    public void ValidateYamlFile_AcceptsDocumentedTransfersGroupsPlacement()
+    {
+        var controller = CreateController();
+        var yaml = $$"""
+            transfers:
+              groups:
+                blacklisted:
+                  patterns:
+                    - '^(?<stem>case)\k<stem>peer$'
+            directories:
+              incomplete: '{{Path.GetTempPath()}}'
+              downloads: '{{Path.GetTempPath()}}'
+            web:
+              content_path: .
+            """;
+        var result = controller.ValidateYamlFile(yaml);
+
+        Assert.IsType<OkResult>(result);
+    }
+
+    [Fact]
+    public void ValidateYamlFile_ValidatesPatternsUnderTransfersGroupsPlacement()
+    {
+        var controller = CreateController();
+
+        var result = controller.ValidateYamlFile($$"""
+            transfers:
+              groups:
+                blacklisted:
+                  patterns:
+                    - '[invalid'
+            directories:
+              incomplete: '{{Path.GetTempPath()}}'
+              downloads: '{{Path.GetTempPath()}}'
+            web:
+              content_path: .
+            """);
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        Assert.Equal("Invalid YAML configuration", ok.Value);
+    }
+
+    [Fact]
+    public void ValidateYamlFile_TopLevelGroupsOverrideTransfersGroupsCompatibilityValues()
+    {
+        var controller = CreateController();
+
+        var result = controller.ValidateYamlFile($$"""
+            transfers:
+              groups:
+                blacklisted:
+                  patterns:
+                    - '[invalid'
+            groups:
+              blacklisted:
+                patterns:
+                  - '^valid$'
+            directories:
+              incomplete: '{{Path.GetTempPath()}}'
+              downloads: '{{Path.GetTempPath()}}'
+            web:
+              content_path: .
+            """);
+
+        Assert.IsType<OkResult>(result);
+    }
+
+    [Fact]
     public void ApplyOverlay_WithInvalidOverlay_DoesNotLeakValidationMessage()
     {
         var controller = CreateController();


### PR DESCRIPTION
## Summary
- normalize the documented `transfers.groups` compatibility placement before strict options validation
- preserve top-level `groups` precedence while filling missing nested values
- validate regex patterns after compatibility normalization

## Reproduction
`POST /api/v0/options/yaml/validate` returned `"Invalid YAML configuration"` for the `transfers.groups` layout shipped in `config/slskd.example.yml`, even though the runtime YAML provider accepts and binds that layout.

## Tests
- `dotnet test tests/slskd.Tests.Unit/slskd.Tests.Unit.csproj -c Release --no-restore --filter "FullyQualifiedName~OptionsControllerTests|FullyQualifiedName~YamlConfigurationSourceTests"`
- 19 passed
