### PR TITLE
Preserve search filter case mode after reload

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,6 +22,8 @@ For dev or build tags, use the same logical version string embedded in the tag.
 
 ## [Unreleased]
 
+- Reloaded search-request filters now preserve the configured regex case mode
+  instead of always becoming case-sensitive after an options change.
 - The web footer and README now offer direct PayPal and Ko-fi links for
   supporting slskdN development.
 - GitLab CI configuration now keeps the Arch package-smoke sudoers command as

--- a/src/slskd/Application.cs
+++ b/src/slskd/Application.cs
@@ -186,17 +186,9 @@ namespace slskd
 
             Flags = Program.Flags;
 
-            var regexOptions = RegexOptions.Compiled;
-
-            if (!Flags.CaseSensitiveRegEx)
-            {
-                regexOptions |= RegexOptions.IgnoreCase;
-            }
-
-            CompiledSearchRequestFilters = OptionsAtStartup.Filters.Search.Request
-                .Select(f => new Regex(f, regexOptions, SearchRequestFilterMatchTimeout))
-                .ToList()
-                .AsReadOnly();
+            CompiledSearchRequestFilters = CompileSearchRequestFilters(
+                OptionsAtStartup.Filters.Search.Request,
+                Flags.CaseSensitiveRegEx);
 
             State = state;
             RegisterChange(State.OnChange(state => State_OnChange(state)));
@@ -780,6 +772,23 @@ namespace slskd
                 searchResponseCache: new SearchResponseCache(),
                 searchResponseResolver: searchResponseResolver,
                 placeInQueueResolver: placeInQueueResolver);
+        }
+
+        internal static IReadOnlyList<Regex> CompileSearchRequestFilters(
+            IEnumerable<string> filters,
+            bool caseSensitive)
+        {
+            var regexOptions = RegexOptions.Compiled;
+
+            if (!caseSensitive)
+            {
+                regexOptions |= RegexOptions.IgnoreCase;
+            }
+
+            return filters
+                .Select(f => new Regex(f, regexOptions, SearchRequestFilterMatchTimeout))
+                .ToList()
+                .AsReadOnly();
         }
 
         private static UserEndPointCache CreateUserEndPointCache()
@@ -2242,10 +2251,9 @@ namespace slskd
                 if (PreviousOptions.Filters.Search.Request.Except(newOptions.Filters.Search.Request).Any()
                     || newOptions.Filters.Search.Request.Except(PreviousOptions.Filters.Search.Request).Any())
                 {
-                    CompiledSearchRequestFilters = newOptions.Filters.Search.Request
-                        .Select(f => new Regex(f, RegexOptions.Compiled, SearchRequestFilterMatchTimeout))
-                        .ToList()
-                        .AsReadOnly();
+                    CompiledSearchRequestFilters = CompileSearchRequestFilters(
+                        newOptions.Filters.Search.Request,
+                        Flags.CaseSensitiveRegEx);
 
                     Log.Information("Updated and re-compiled search response filters");
                 }

--- a/tests/slskd.Tests.Unit/Core/ApplicationLifecycleTests.cs
+++ b/tests/slskd.Tests.Unit/Core/ApplicationLifecycleTests.cs
@@ -73,6 +73,18 @@ public class ApplicationLifecycleTests
         Assert.Null(patch.ListenPort);
     }
 
+    [Theory]
+    [InlineData(false, true)]
+    [InlineData(true, false)]
+    public void CompileSearchRequestFilters_PreservesConfiguredCaseMode(
+        bool caseSensitive,
+        bool expectedMatch)
+    {
+        var filters = Application.CompileSearchRequestFilters(["^secret$"], caseSensitive);
+
+        Assert.Equal(expectedMatch, filters[0].IsMatch("SECRET"));
+    }
+
     [Fact]
     public void FormatCompletedTransferProgress_ClampsNegativeAverageSpeed()
     {


### PR DESCRIPTION
## Summary

- centralize search-request filter compilation
- apply the configured case-sensitive regex flag at startup and after options reload
- add regression coverage for both case modes

## Bug

Startup compilation adds RegexOptions.IgnoreCase when case-sensitive regex mode is disabled. The options-change handler previously recompiled changed filters with RegexOptions.Compiled alone, silently making the same configured filters case-sensitive after a reload.

## Verification

- dotnet test tests/slskd.Tests.Unit/slskd.Tests.Unit.csproj -c Release --filter FullyQualifiedName~ApplicationLifecycleTests
- 9 passed, 0 failed