### PR TITLE
Return 413 for oversized request bodies

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,6 +22,8 @@ For dev or build tags, use the same logical version string embedded in the tag.
 
 ## [Unreleased]
 
+- Oversized HTTP request bodies now return a bounded 413 Problem Details
+  response instead of being reported as an internal server error.
 - Release council backlog validation now regenerates its derived report on
   every run and scans only Git-tracked repository roots. Local ignored reports,
   dependency trees, build outputs, and optional directories can no longer make

--- a/src/slskd/Bootstrap/WebApplicationPipelineExtensions.cs
+++ b/src/slskd/Bootstrap/WebApplicationPipelineExtensions.cs
@@ -65,6 +65,12 @@ public static class WebApplicationPipelineExtensions
                         title = "Not Implemented";
                         detail = fe.Message;
                     }
+                    else if (ex is BadHttpRequestException { StatusCode: StatusCodes.Status413PayloadTooLarge })
+                    {
+                        status = StatusCodes.Status413PayloadTooLarge;
+                        title = "Payload Too Large";
+                        detail = "Request body too large.";
+                    }
                     else
                     {
                         var env = context.RequestServices.GetService<Microsoft.AspNetCore.Hosting.IWebHostEnvironment>();

--- a/tests/slskd.Tests/ExceptionHandlerTestHostFactory.cs
+++ b/tests/slskd.Tests/ExceptionHandlerTestHostFactory.cs
@@ -11,6 +11,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Diagnostics;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Authorization;
 using Microsoft.AspNetCore.Mvc.Testing;
@@ -92,6 +93,12 @@ public class ExceptionHandlerTestHostFactory : WebApplicationFactory<ProgramStub
                                     status = 501;
                                     title = "Not Implemented";
                                     detail = fe.Message;
+                                }
+                                else if (ex is BadHttpRequestException { StatusCode: StatusCodes.Status413PayloadTooLarge })
+                                {
+                                    status = StatusCodes.Status413PayloadTooLarge;
+                                    title = "Payload Too Large";
+                                    detail = "Request body too large.";
                                 }
                                 else
                                 {

--- a/tests/slskd.Tests/ExceptionHandlerTests.cs
+++ b/tests/slskd.Tests/ExceptionHandlerTests.cs
@@ -77,4 +77,25 @@ public class ExceptionHandlerTests
         Assert.Equal("Not Implemented", root.GetProperty("title").GetString());
         Assert.Contains("not implemented", root.GetProperty("detail").GetString() ?? "", StringComparison.OrdinalIgnoreCase);
     }
+
+    [Fact]
+    public async Task Exception_handler_body_limit_exception_returns_413_without_leaking_limit()
+    {
+        using var factory = new ExceptionHandlerTestHostFactory();
+        using var client = factory.CreateClient();
+        using var response = await client.GetAsync("/api/v0/throw/payload-too-large");
+
+        Assert.Equal(HttpStatusCode.RequestEntityTooLarge, response.StatusCode);
+        Assert.Equal("application/problem+json", response.Content.Headers.ContentType?.MediaType);
+
+        var json = await response.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+        Assert.Equal(413, root.GetProperty("status").GetInt32());
+        Assert.Equal("Payload Too Large", root.GetProperty("title").GetString());
+        Assert.Equal("Request body too large.", root.GetProperty("detail").GetString());
+        Assert.True(root.TryGetProperty("traceId", out var traceId));
+        Assert.False(string.IsNullOrWhiteSpace(traceId.GetString()));
+        Assert.DoesNotContain("1024", json);
+    }
 }

--- a/tests/slskd.Tests/ThrowController.cs
+++ b/tests/slskd.Tests/ThrowController.cs
@@ -4,6 +4,7 @@
 namespace slskd.Tests;
 
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using slskd;
 
@@ -31,5 +32,16 @@ public class ThrowController : ControllerBase
     public IActionResult GetNotImplemented()
     {
         throw new FeatureNotImplementedException("Test feature is not implemented.");
+    }
+
+    /// <summary>
+    /// GET /api/v0/throw/payload-too-large — reproduces Kestrel's body-limit exception.
+    /// </summary>
+    [HttpGet("payload-too-large")]
+    public IActionResult GetPayloadTooLarge()
+    {
+        throw new BadHttpRequestException(
+            "Request body too large. The max request body size is 1024 bytes.",
+            StatusCodes.Status413PayloadTooLarge);
     }
 }


### PR DESCRIPTION
## Summary

- map Kestrel request-body-limit exceptions to 413 Problem Details
- avoid leaking the configured byte limit
- add focused exception-handler regression coverage

## Verification

- `dotnet test tests/slskd.Tests/slskd.Tests.csproj --configuration Release --filter FullyQualifiedName~ExceptionHandlerTests`
- `bash scripts/check-remediation-baseline.sh`

Discovered while differentially testing slskR against frozen slskdN: a body one byte over `web.max_request_body_size` was reported as a generic 500.
