### PR TITLE
Honor forced disaster mode at startup

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,6 +22,8 @@ For dev or build tags, use the same logical version string embedded in the tag.
 
 ## [Unreleased]
 
+- Forced VirtualSoulfind disaster mode now starts the coordinator in full
+  fallback instead of exposing the configured override without applying it.
 - Release gates now fail unconditionally when a command exceeds its timeout,
   streaming pipe regressions dispose their leases on every assertion path, and
   COPR uploads retry bounded transient API failures using the verified SRPM

--- a/src/slskd/VirtualSoulfind/DisasterMode/DisasterModeCoordinator.cs
+++ b/src/slskd/VirtualSoulfind/DisasterMode/DisasterModeCoordinator.cs
@@ -102,8 +102,11 @@ public sealed class DisasterModeCoordinator : IDisasterModeCoordinator
         // Subscribe to health changes.
         healthMonitor.HealthChanged += OnHealthChanged;
 
-        // Start in normal mode (Soulseek + mesh together).
-        currentLevel = DisasterModeLevel.Normal;
+        // Honor the explicit test/operator override at startup. Previously the
+        // option was bound and exposed through the options API but never read.
+        currentLevel = optionsMonitor.CurrentValue.VirtualSoulfind?.DisasterMode?.Force == true
+            ? DisasterModeLevel.FullFallback
+            : DisasterModeLevel.Normal;
     }
 
     public DisasterModeLevel CurrentLevel

--- a/tests/slskd.Tests.Unit/VirtualSoulfind/DisasterMode/DisasterModeLifecycleTests.cs
+++ b/tests/slskd.Tests.Unit/VirtualSoulfind/DisasterMode/DisasterModeLifecycleTests.cs
@@ -13,6 +13,27 @@ using Xunit;
 public class DisasterModeLifecycleTests
 {
     [Fact]
+    public void DisasterModeCoordinator_Force_StartsInFullFallback()
+    {
+        var healthMonitor = new Mock<ISoulseekHealthMonitor>();
+        var optionsMonitor = new Mock<IOptionsMonitor<slskd.Options>>();
+        optionsMonitor.Setup(x => x.CurrentValue).Returns(new slskd.Options
+        {
+            VirtualSoulfind = new slskd.Core.VirtualSoulfindOptions
+            {
+                DisasterMode = new DisasterModeOptions { Force = true },
+            },
+        });
+        using var coordinator = new DisasterModeCoordinator(
+            NullLogger<DisasterModeCoordinator>.Instance,
+            healthMonitor.Object,
+            optionsMonitor.Object);
+
+        Assert.Equal(DisasterModeLevel.FullFallback, coordinator.CurrentLevel);
+        Assert.True(((IDisasterModeCoordinator)coordinator).IsDisasterModeActive);
+    }
+
+    [Fact]
     public void SoulseekClientWrapper_Dispose_UnsubscribesRoomMessageProxy()
     {
         var soulseekClient = new Mock<Soulseek.ISoulseekClient>();


### PR DESCRIPTION
## What changed

- initialize `DisasterModeCoordinator` in `FullFallback` when `virtualSoulfind.disasterMode.force` is enabled
- add focused lifecycle coverage for the forced startup state

## Why

The option was bound from configuration and exposed through the options API, but the coordinator always initialized in `Normal`, so the documented force override had no runtime effect.

## Impact

Operators and tests that explicitly enable the force override now receive the requested full fallback state immediately at startup. The default remains `Normal`.

## Validation

- `dotnet test tests/slskd.Tests.Unit/slskd.Tests.Unit.csproj -c Release --filter FullyQualifiedName~DisasterModeLifecycleTests --no-restore`
- 4 passed, 0 failed
